### PR TITLE
Escaped escape char before segment delimiter

### DIFF
--- a/src/EdiWeave.Framework/Readers/EdiReader.cs
+++ b/src/EdiWeave.Framework/Readers/EdiReader.cs
@@ -168,6 +168,8 @@ namespace EdiWeave.Framework.Readers
 
                 if (Separators.Escape.HasValue &&
                     line.EndsWith(string.Concat(Separators.Escape.Value, Separators.Segment),
+                        StringComparison.Ordinal) &&
+                    !line.EndsWith(string.Concat(Separators.Escape.Value, Separators.Escape.Value, Separators.Segment),
                         StringComparison.Ordinal))
                     continue;
 


### PR DESCRIPTION
Current check only checks for an escaped segment delimiter. If the escape char itself is escaped the segment delimiter ist not recognized. ex: RFF+ON:??!